### PR TITLE
Add build mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM quay.io/fedora/fedora:39
+
+COPY . .

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+IMAGE_NAME="quay.io/app-sre/test-dockerignore-builds"
+IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+
+GIT_STATUS=$(git status -su)
+if [[ -n "$GIT_STATUS" ]]; then
+    echo "Non empty git status [$GIT_STATUS]"
+    exit 1
+fi
+
+docker build -t "${IMAGE_NAME}:latest" .
+docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:${IMAGE_TAG}"
+
+DOCKER_CONF="${PWD}/.docker"
+mkdir -p "${DOCKER_CONF}"
+docker --config="${DOCKER_CONF}" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
+
+docker --config="${DOCKER_CONF}" push "${IMAGE_NAME}:latest"
+docker --config="${DOCKER_CONF}" push "${IMAGE_NAME}:${IMAGE_TAG}"


### PR DESCRIPTION
We add the infamous "COPY . ." statement so that we make sure we copy any credentials if we don't have a local .dockerignore.

The build script follows the problematic pattern of keeping credentials locally. It also fails if untracked or modified files are present to make sure whatever we do won't make git complain.

We have made sure the repository is public.